### PR TITLE
Upgrade project to work with 5.1-EA-2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ target/
 .classpath
 .project 
 .settings
+**.iml
+.idea

--- a/alfresco-demo-data-exporter-repo-amp/pom.xml
+++ b/alfresco-demo-data-exporter-repo-amp/pom.xml
@@ -32,6 +32,7 @@
 		</dependency>
 		<!-- Uncomment if you are using RM (Records Management) module, brings 
 			in RM related classes -->
+		<!--
 		<dependency>
 			<groupId>${alfresco.groupId}</groupId>
 			<artifactId>alfresco-rm</artifactId>
@@ -39,6 +40,7 @@
 			<classifier>classes</classifier>
 			<scope>provided</scope>
 		</dependency>
+		-->
 
 		<dependency>
 			<groupId>org.alfresco</groupId>

--- a/alfresco-demo-data-repo-amp/pom.xml
+++ b/alfresco-demo-data-repo-amp/pom.xml
@@ -32,6 +32,7 @@
 		</dependency>
 		<!-- Uncomment if you are using RM (Records Management) module, brings 
 			in RM related classes -->
+
 		<dependency>
 			<groupId>${alfresco.groupId}</groupId>
 			<artifactId>alfresco-rm</artifactId>
@@ -39,6 +40,7 @@
 			<classifier>classes</classifier>
 			<scope>provided</scope>
 		</dependency>
+
 
 		<dependency>
 			<groupId>org.alfresco</groupId>

--- a/alfresco-demo-data-repo-amp/src/main/amp/config/alfresco/module/alfresco-demo-data-repo-amp/context/dynamic-bootstrap-context.xml
+++ b/alfresco-demo-data-repo-amp/src/main/amp/config/alfresco/module/alfresco-demo-data-repo-amp/context/dynamic-bootstrap-context.xml
@@ -4,18 +4,21 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
           http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
-
+<!--
 	<bean class="org.alfresco.devops.services.DynamicBootstrapPatchPostProcessor">
 		<property name="resourcesResolver" ref="resourcesResolver" />
 		<property name="sitesDisabled"><value>false</value></property>
 		<property name="rmFixDisabled"><value>false</value></property>
 		<property name="authoritiesDisabled"><value>false</value></property>
+
+
 		<property name="sitesContentLocation" value="alfresco/module/${project.artifactId}/bootstrap/dynamic/sites/**/Contents.acp" />
+
 		<property name="usersLocation" value="alfresco/module/${project.artifactId}/bootstrap/dynamic/authorities/Users.acp" />
 		<property name="peopleLocation" value="alfresco/module/${project.artifactId}/bootstrap/dynamic/authorities/People.acp" />
 		<property name="groupsLocation" value="alfresco/module/${project.artifactId}/bootstrap/dynamic/authorities/Groups.json" />
 	</bean>
 
-
+-->
 
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.alfresco.maven</groupId>
 		<artifactId>alfresco-sdk-parent</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1</version>
 	</parent>
 
 	<scm>
@@ -36,13 +36,20 @@
 
 
 	<properties>
-		<!-- <alfresco.version>5.0.d</alfresco.version> -->
+		<alfresco.version>5.1-EA-2</alfresco.version>
 		<alfresco.rm.version>2.3</alfresco.rm.version>
-		<!-- <alfresco.data.location>alf_data_dev</alfresco.data.location> -->
+		<alfresco.data.location>${session.executionRootDirectory}/alf_data_dev</alfresco.data.location>
 		<!-- <app.log.root.level>WARN</app.log.root.level> -->
 		<!-- <env>local</env> -->
 		<share.client.url>http://localhost:8080/share</share.client.url>
 	</properties>
+
+	<repositories>
+		<repository>
+			<id>alfresco-ea-repo</id>
+			<url>https://artifacts.alfresco.com/nexus/content/repositories/5.1-EA</url>
+		</repository>
+	</repositories>
 
 	<!-- Here we realize the connection with the Alfresco selected platform 
 		(e.g.version and edition) -->

--- a/repo/pom.xml
+++ b/repo/pom.xml
@@ -33,12 +33,15 @@
 		</dependency>
 		<!-- Demonstrating the dependency / installation of the repo AMP developed 
 			in the 'repo-amp' module -->
+		<!--
 		<dependency>
 			<groupId>${alfresco.groupId}</groupId>
 			<artifactId>alfresco-rm</artifactId>
 			<version>${alfresco.rm.version}</version>
 			<type>amp</type>
 		</dependency>
+		-->
+		<!--
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>alfresco-demo-data-repo-amp</artifactId>
@@ -51,6 +54,7 @@
 			<version>${project.version}</version>
 			<type>amp</type>
 		</dependency>
+		-->
 		<!-- Uncomment if you are using SPP (SharePoint Protocol Support) for Online 
 			Edit etc -->
 		<!-- <dependency> <groupId>${alfresco.groupId}</groupId> <artifactId>alfresco-spp</artifactId> 
@@ -88,12 +92,15 @@
 							<!-- To allow inclusion of META-INF -->
 							<excludes />
 						</overlay>
+						<!--
 						<overlay>
 							<groupId>${alfresco.groupId}</groupId>
 							<artifactId>alfresco-rm</artifactId>
 							<type>amp</type>
 						</overlay>
+						-->
 						<!-- Add / sort your AMPs here -->
+						<!--
 						<overlay>
 							<groupId>${project.groupId}</groupId>
 							<artifactId>alfresco-demo-data-repo-amp</artifactId>
@@ -104,6 +111,7 @@
 							<artifactId>alfresco-demo-data-exporter-repo-amp</artifactId>
 							<type>amp</type>
 						</overlay>
+						-->
 						<!-- Uncomment if you are using SPP -->
 						<!-- <overlay> <groupId>${alfresco.groupId}</groupId> <artifactId>alfresco-spp</artifactId> 
 							<type>amp</type> </overlay> -->

--- a/run.sh
+++ b/run.sh
@@ -6,6 +6,8 @@ springloadedfile=~/.m2/repository/org/springframework/springloaded/1.2.3.RELEASE
 if [ ! -f $springloadedfile ]; then
 mvn validate -Psetup
 fi
-MAVEN_OPTS="-javaagent:$springloadedfile -noverify -Xms256m -Xmx2G" mvn clean install -Prun
+# 5.1 + spring loaded != good combo right now
+MAVEN_OPTS="-noverify -Xms256m -Xmx2G" mvn clean install -Prun
+#MAVEN_OPTS="-javaagent:$springloadedfile -noverify -Xms256m -Xmx2G" mvn clean install -Prun
 #MAVEN_OPTS="-noverify -Xms256m -Xmx2G" mvn clean install -Prun
 #MAVEN_OPTS="-javaagent:$springloadedfile -noverify -Xms256m -Xmx2G -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=1044" mvn clean install -Prun

--- a/runner/pom.xml
+++ b/runner/pom.xml
@@ -20,7 +20,7 @@
 			<!-- TODO: figure out a way to define these properties in a parent POM, 
 				they are now also duplicated in the solr-config/pom.xml -->
 			<properties>
-				<alfresco.solr.dir>${project.parent.basedir}/${alfresco.data.location}/solr4</alfresco.solr.dir>
+				<alfresco.solr.dir>${alfresco.data.location}/solr4</alfresco.solr.dir>
 				<alfresco.solr.home.dir>${alfresco.solr.dir}/config</alfresco.solr.home.dir>
 			</properties>
 
@@ -63,6 +63,25 @@
 					<plugin>
 						<groupId>org.apache.tomcat.maven</groupId>
 						<artifactId>tomcat7-maven-plugin</artifactId>
+						<dependencies>
+							<dependency>
+								<groupId>org.alfresco</groupId>
+								<artifactId>alfresco-repository</artifactId>
+								<version>${alfresco.version}</version>
+								<classifier>h2scripts</classifier>
+								<exclusions>
+									<exclusion>
+										<groupId>*</groupId>
+										<artifactId>*</artifactId>
+									</exclusion>
+								</exclusions>
+							</dependency>
+							<dependency>
+								<groupId>org.codehaus.plexus</groupId>
+								<artifactId>plexus-archiver</artifactId>
+								<version>2.3</version>
+							</dependency>
+						</dependencies>
 						<executions>
 							<execution>
 								<id>run-wars</id>

--- a/share/pom.xml
+++ b/share/pom.xml
@@ -35,12 +35,14 @@
 			<type>amp</type>
 		</dependency>
 			<!-- Uncomment if you are using RM (Records Management) module -->
+		<!--
 		<dependency>
 			<groupId>${alfresco.groupId}</groupId>
 			<artifactId>alfresco-rm-share</artifactId>
 			<version>${alfresco.rm.version}</version>
 			<type>amp</type>
 		</dependency>
+		-->
 	</dependencies>
 
 	<build>
@@ -53,8 +55,32 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>unpack</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>unpack-dependencies</goal>
+						</goals>
+						<configuration>
+							<includeTypes>war</includeTypes>
+							<includeGroupIds>org.alfresco</includeGroupIds>
+							<includeArtifactIds>share</includeArtifactIds>
+							<includes>META-INF/MANIFEST.MF</includes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<artifactId>maven-war-plugin</artifactId>
 				<configuration>
+					<archive>
+						<addMavenDescriptor>false</addMavenDescriptor>
+						<manifestFile>${project.build.directory}/dependency/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+					<webResources>
+					</webResources>
 					<!-- Here is can control the order of overlay of your (WAR, AMP, etc.) 
 						dependencies | NOTE: At least one WAR dependency must be uncompressed first 
 						| NOTE: In order to have a dependency effectively added to the WAR you need 
@@ -72,17 +98,21 @@
 							<excludes />
 						</overlay>
 						<!-- Add / sort your AMPs here -->
+						<!--
 						<overlay>
 							<groupId>${project.groupId}</groupId>
 							<artifactId>alfresco-demo-data-share-amp</artifactId>
 							<type>amp</type>
 						</overlay>
+						-->
 											<!-- Uncomment if you are using RM module -->
+						<!--
 						<overlay>
 							<groupId>${alfresco.groupId}</groupId>
 							<artifactId>alfresco-rm-share</artifactId>
 							<type>amp</type>
 						</overlay>
+						-->
 					</overlays>
 				</configuration>
 			</plugin>

--- a/solr-config/pom.xml
+++ b/solr-config/pom.xml
@@ -24,7 +24,7 @@
 			<id>run</id>
 
 			<properties>
-				<alfresco.solr.dir>${project.parent.basedir}/${alfresco.data.location}/solr4</alfresco.solr.dir>
+				<alfresco.solr.dir>${alfresco.data.location}/solr4</alfresco.solr.dir>
 				<alfresco.solr.home.dir>${alfresco.solr.dir}/config</alfresco.solr.home.dir>
 				<alfresco.solr.data.dir>${alfresco.solr.dir}/data</alfresco.solr.data.dir>
 			</properties>
@@ -50,6 +50,9 @@
 							<skip>true</skip>
 						</configuration>
 					</plugin>
+					<!-- Run goal unpack and unzip the content of the downloaded default solr-config.zip file into the
+                         alfresco-maven-sdk2-test/alf_data_dev/solr4/config directory
+                         (The solr-config.zip is brought in via the dependency section) -->
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-dependency-plugin</artifactId>
@@ -76,8 +79,8 @@
 						</executions>
 					</plugin>
 
-					<!-- For windows paths, convert single \ to / for the ${alfresco.solr.data.dir} 
-						path, by default it will be c:\bla\, we need forward slash or double backslash. -->
+					<!-- For windows paths, convert single \ to / for the ${alfresco.solr.data.dir} path,
+                         by default it will be c:\bla\, we need forward slash or double backslash. -->
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>build-helper-maven-plugin</artifactId>
@@ -100,8 +103,8 @@
 					</plugin>
 
 
-					<!-- Run the goal replace and update configuration files for the Solr 
-						cores to reflect our build structure -->
+					<!-- Run the goal replace and update configuration files for the
+                         Solr cores to reflect our build structure -->
 					<plugin>
 						<groupId>com.google.code.maven-replacer-plugin</groupId>
 						<artifactId>replacer</artifactId>
@@ -127,6 +130,7 @@
 								</replacement>
 							</replacements>
 						</configuration>
+
 					</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
Upgraded the project to work with 5.1-EA-2. Had to comment out the bootstrap process as there is a module that requires RM, but RM doesn't work (see TAA-426). In the current state it should boot up just fine with 5.1-EA-2. 